### PR TITLE
Add pointerDetails to explainer

### DIFF
--- a/pointer-event-device-id-explainer.md
+++ b/pointer-event-device-id-explainer.md
@@ -11,14 +11,14 @@ This is the repository for pointer-event-extensions. You're welcome to
 ## Participate
 - [Issue tracker](https://github.com/WICG/pointer-event-extensions/issues)
 
-# Extending the PointerEvent with Unique DeviceId Attribute
+# Extending the PointerEvent with deviceProperties.uniqueId
 
 ## Status of this Document
 
 This document is a starting point for engaging the community and standards bodies in developing collaborative solutions fit for standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
 
 ## Introduction
-As devices with advanced pen input capabilities are becoming increasingly prevalent, it is important that the web platform continues to evolve to fully support these advanced features in order to unlock rich experiences for both end users and developers. One such advancement is the ability for a device's digitizer to recognize more than one pen device interacting with it simultaneously. In this Explainer, we propose an extension to the `PointerEvent` interface to include a new attribute, `deviceId`, that represents a session-persistent, document isolated, unique identifier that a developer can reliably use to identify individual pens interacting with the page.
+As devices with advanced pen input capabilities are becoming increasingly prevalent, it is important that the web platform continues to evolve to fully support these advanced features in order to unlock rich experiences for both end users and developers. One such advancement is the ability for a device's digitizer to recognize more than one pen device interacting with it simultaneously. In this Explainer, we propose an extension to the `PointerEvent` interface to include a new attribute, `deviceProperties`, which is an interface that will contain the `uniqueId` attribute; that represents a session-persistent, document isolated, unique identifier that a developer can reliably use to identify individual pens interacting with the page.
 
 ## Goals
 1. Provide web developers with access to a reliable unique identifier for each pen interacting with a page.
@@ -26,13 +26,17 @@ As devices with advanced pen input capabilities are becoming increasingly preval
 
 ## Alternative Solutions
 ### PointerEvent.pointerId 
-Changes to the PointerEvent specification outlined [here](https://github.com/w3c/pointerevents/commit/d5e6171c04d5fbb336220db1bfe39ee8d1321635) allow `PointerEvent.pointerId` to be used as a unique device ID. However, there are certain pen devices that do not yield a device ID from the hardware itself, making it impossible to distinguish between a pen that supports persistent ID and a pen that does not. If we were to use `pointerId`, devices that do not support hardware ID will appear as a new `pointerId` for each event, while pens that do support hardware ID will reuse a stable `pointerId`. By introducing `deviceId`, we can make this capability distinction clear to the developer.
+Changes to the PointerEvent specification outlined [here](https://github.com/w3c/pointerevents/commit/d5e6171c04d5fbb336220db1bfe39ee8d1321635) allow `PointerEvent.pointerId` to be used as a unique device ID. However, there are certain pen devices that do not yield a device ID from the hardware itself, making it impossible to distinguish between a pen that supports persistent ID and a pen that does not. If we were to use `pointerId`, devices that do not support hardware ID will appear as a new `pointerId` for each event, while pens that do support hardware ID will reuse a stable `pointerId`. By introducing `uniqueId`, we can make this capability distinction clear to the developer.
 
 ## Featured Use Case
-Microsoft's Surface Hub device supports detection of multiple pen devices interacting with the digitizer simultaneously. Microsoft Whiteboard takes advantage of this capability in their native Win32 application to provide a rich multi-user inking experience. Microsoft Whiteboard also ships as a web application, but browser support for multiple pen detection does not exist and creates a feature gap between the native application and the web application. Augmenting `PointerEvent` with `deviceId`,  will enable the web application to reach parity with the native desktop application. In addition to Whiteboard, other applications such as Google Jamboard can also utilize this API.
+Microsoft's Surface Hub device supports detection of multiple pen devices interacting with the digitizer simultaneously. Microsoft Whiteboard takes advantage of this capability in their native Win32 application to provide a rich multi-user inking experience. Microsoft Whiteboard also ships as a web application, but browser support for multiple pen detection does not exist and creates a feature gap between the native application and the web application. Augmenting `PointerEvent` with `deviceProperties.uniqueId`,  will enable the web application to reach parity with the native desktop application. In addition to Whiteboard, other applications such as Google Jamboard can also utilize this API.
 
 ## Proposed Solution
-The proposed solution is to add a new attribute `deviceId` to `PointerEvent` that has the following characteristics:
+
+### PointerEvent.deviceProperties
+Rather than adding a device identifier attribute directly to the `PointerEvent` interface, parenting it with `deviceProperties` allows for future device-specific additions to `PointerEvent` without polluting the main `PointerEvent` interface.
+
+The proposed solution is to add a new attribute `uniqueId` to `PointerEvent.deviceProperties` that has the following characteristics:
 
 1. The attribute will be populated if both the digitizer and the pen support getting a unique hardware ID for the pen, with a value of 2 or more.
 1. The attribute will be `-1` if the digitizer and pen support getting a unique hardware ID, but the ID is not available during the current event due to limitations (see [Limitations of Current Hardware](#limitations-of-current-hardware)).
@@ -43,8 +47,14 @@ The proposed solution is to add a new attribute `deviceId` to `PointerEvent` tha
 The proposed WebIDL for this feature is as follows:
 
 ```webidl
+interface deviceProperties {
+    readonly attribute long uniqueId;
+}
+```
+
+```webidl
 partial interface PointerEvent {
-    readonly attribute unsigned long? deviceId;
+    readonly attribute DeviceProperties? deviceProperties;
 }
 ```
 
@@ -66,22 +76,22 @@ This ID allows the developer to assign a different inking color to each unique p
 
             const canvas = document.querySelector('#inking-surface');
 
-            // Listen for a `pointerdown` event and map the deviceId to a color if it exists
+            // Listen for a `pointerdown` event and map the uniqueId to a color if it exists
             // and has not been mapped yet.
             canvas.addEventListener('pointerdown', function(e) {
-                if (e.deviceId && (e.deviceId > 1) && !pen_to_color_map.has(e.deviceId)) {
-                    pen_to_color_map.set(e.deviceId, COLORS[color_assignment_index]);
+                if (e.deviceProperties.uniqueId && (e.deviceProperties.uniqueId > 1) && !pen_to_color_map.has(e.deviceProperties.uniqueId)) {
+                    pen_to_color_map.set(e.deviceProperties.uniqueId, COLORS[color_assignment_index]);
 
                     // Bump the color assignment index and loop back over if needed
                     color_assignment_index = (color_assignment_index + 1) % COLORS.length;
                 }
             });
 
-            // Listen for a `pointermove` and get the color assigned to this pen if deviceId exists
+            // Listen for a `pointermove` and get the color assigned to this pen if uniqueId exists
             // and the pen has been color mapped.
             canvas.addEventListener('pointermove', function(e) {
-                if (e.deviceId && pen_to_color_map.has(e.deviceId)) {
-                    const pen_color = pen_to_color_map.get(e.deviceId);
+                if (e.deviceProperties.uniqueId && pen_to_color_map.has(e.deviceProperties.uniqueId)) {
+                    const pen_color = pen_to_color_map.get(e.deviceProperties.uniqueId);
 
                     // ... Do some inking on the <canvas> ...
                 }
@@ -92,9 +102,9 @@ This ID allows the developer to assign a different inking color to each unique p
 ```
 
 ### Limitations of Current Hardware
-The ability to gather a unique hardware ID from the pen is a fairly new capability. For example, on the Surface Hub 2S and later, the hardware ID is accessible for all events. This means that all events (`pointerdown`, `pointermove`, `pointerenter` etc.) will have access to the unique hardware ID and thus will have the `deviceId` populated. The same cannot be said for Surface Laptop and Surface Devices with older generations of Surface Pen. Because of this, the following table will be used to determine the value of `deviceId`:
+The ability to gather a unique hardware ID from the pen is a fairly new capability. For example, on the Surface Hub 2S and later, the hardware ID is accessible for all events. This means that all events (`pointerdown`, `pointermove`, `pointerenter` etc.) will have access to the unique hardware ID and thus will have the `uniqueId` populated. The same cannot be said for Surface Laptop and Surface Devices with older generations of Surface Pen. Because of this, the following table will be used to determine the value of `uniqueId`:
 
-| Scenario | Value of `deviceId` |
+| Scenario | Value of `uniqueId` |
 | :- | :- |
 | Digitizer and Pen support Hardware ID on OS | `signed long` |
 | Digitizer and Pen support Hardware ID, but not for initial contact | `-1` |

--- a/pointer-event-device-id-explainer.md
+++ b/pointer-event-device-id-explainer.md
@@ -47,7 +47,7 @@ The proposed solution is to add a new attribute `uniqueId` to `PointerEvent.devi
 The proposed WebIDL for this feature is as follows:
 
 ```webidl
-interface deviceProperties {
+dictionary DeviceProperties {
     readonly attribute long uniqueId;
 }
 ```


### PR DESCRIPTION
Update the explainer to reflect the changes discussed in the [I2S](https://groups.google.com/a/chromium.org/g/blink-dev/c/3eU-AHH8x4k/m/rCyxcYnQAgAJ?pli=1). deviceId will be replaced with a pointerDetails struct that contains the uniqueId attribute.